### PR TITLE
fix: add --first-only flag in findmnt

### DIFF
--- a/srv/salt/omv/deploy/fstab/15mergerfsfolders.sls
+++ b/srv/salt/omv/deploy/fstab/15mergerfsfolders.sls
@@ -21,7 +21,7 @@
 {% if dir | length > 2 %}
 {% set _ = branches.append(dir) %}
 {% if '*' not in dir %}
-{% set parent = salt['cmd.shell']('findmnt --noheadings --output TARGET --target ' + dir) %}
+{% set parent = salt['cmd.shell']('findmnt --first-only --noheadings --output TARGET --target ' + dir) %}
 {% if not pool.xsystemd %}
 {% if parent | length > 1 %}
 {% set _ = options.append('x-systemd.requires=' + parent) %}


### PR DESCRIPTION
Add --first-only flag in findmnt to dedup results.
Fixes #2.
